### PR TITLE
fixed  incorrect type hinting for the inherited method from generate command

### DIFF
--- a/src/Command/MigrationsGenerateDoctrineCommand.php
+++ b/src/Command/MigrationsGenerateDoctrineCommand.php
@@ -4,7 +4,7 @@ namespace Rey\BitrixMigrations\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Rey\BitrixMigrations\Configuration\DoctrineConfiguration as Configuration;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 
 class MigrationsGenerateDoctrineCommand extends GenerateCommand
@@ -19,7 +19,7 @@ class MigrationsGenerateDoctrineCommand extends GenerateCommand
     }
 
     /**
-     * @param \Rey\BitrixMigrations\Configuration\DoctrineConfiguration $configuration
+     * @param Doctrine\DBAL\Migrations\Configuration\Configuration $configuration
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param string $version
      * @param string|null $up


### PR DESCRIPTION
This will cause strict standards kind of error with not compatible declarations of method `Rey\BitrixMigrations\Command\MigrationsGenerateDoctrineCommand::generateMigration()`.
